### PR TITLE
fix mvn site build and introduce a retry on nexus releasing

### DIFF
--- a/.github/workflows/createerelease.yml
+++ b/.github/workflows/createerelease.yml
@@ -165,7 +165,8 @@ jobs:
       run: |
         cd target/checkout
         pwd
-        $MVNCMD nexus-staging:release
+        # There are sometimes temporary failures of OSSRH - we do some retries. If it still fails, manually release at https://oss.sonatype.org/#stagingRepositories
+        $MVNCMD nexus-staging:release || (echo FAILURE 1; sleep 600; $MVNCMD nexus-staging:release) || (echo FAILURE 2; sleep 1200; $MVNCMD nexus-staging:release)
 
     - name: Drop from OSSRH on dryrun
       if: ${{ github.event.inputs.dryrun != 'false' }}
@@ -175,7 +176,7 @@ jobs:
       run: |
         cd target/checkout
         pwd
-        $MVNCMD nexus-staging:drop
+        $MVNCMD nexus-staging:drop || (echo FAILURE 1; sleep 600; $MVNCMD nexus-staging:drop) || (echo FAILURE 2; sleep 1200; $MVNCMD nexus-staging:drop)
 
     - name: List target files even if recipe fails
       if: always()

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,11 @@
             <id>istrepo</id>
             <url>https://repo.ist-software.com/repository/maven-snapshots</url>
         </snapshotRepository>
+        <site>
+            <!-- This is not actually used, but, strangely, the site plugin requires it. -->
+            <id>api.composum.com</id>
+            <url>scp://api.composum.com/var/www/composum/api/public/</url>
+        </site>
     </distributionManagement>
 
     <modules>
@@ -115,6 +120,7 @@
         </profile>
 
     </profiles>
+
     <build>
         <pluginManagement>
             <plugins>
@@ -191,9 +197,86 @@
                     </configuration>
                 </plugin>
 
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.8.2</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.5.0</version>
+                    <configuration>
+                        <quiet>true</quiet>
+                        <notimestamp>true</notimestamp>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.3.0</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>3.5.0</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.8.2</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-project-info-reports-plugin</artifactId>
+                    <version>3.4.2</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.2</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.2</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>2.5.3</version>
+                </plugin>
+
             </plugins>
         </pluginManagement>
     </build>
+
     <dependencyManagement>
         <dependencies>
 


### PR DESCRIPTION
There occasionally seem to be temporarily failures on OSSRH that produce a weird error message saying nothing ( https://issues.sonatype.org/browse/MVNCENTRAL-7987 ). I introduce a retry to hopefully make that very rare.

Also, this fixes the mvn site build on the master branch by introducing some plugin configurations.

But perhaps merge this when time is not pressing, though that shouldn't change anything.